### PR TITLE
Fix Android header issue and a few misc items

### DIFF
--- a/src/views/screens/schedule-screen/schedule-cell/schedule-cell.tsx
+++ b/src/views/screens/schedule-screen/schedule-cell/schedule-cell.tsx
@@ -38,7 +38,7 @@ export class ScheduleCell extends React.Component<ScheduleCellProps, {}> {
           <View style={style.content as ViewStyle}>
             <Text preset="subheader" text={talk.title} style={style.title as TextStyle} />
             {talk.speakers &&
-              talk.speakers[0] &&
+              talk.speakers.length > 0 &&
               talk.speakers[0].name && (
                 <Text
                   preset="subheader"

--- a/src/views/screens/talk-details/talk-details-screen.tsx
+++ b/src/views/screens/talk-details/talk-details-screen.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { View, Image, ViewStyle, TextStyle, Linking, ImageStyle } from "react-native"
+import { View, Image, ViewStyle, TextStyle, Linking, ImageStyle, Platform } from "react-native"
 import { NavigationScreenProps } from "react-navigation"
 import { Screen } from "../../shared/screen"
 import { palette } from "../../../theme/palette"
@@ -79,6 +79,7 @@ const backImage = () => <Image source={require("../../shared/title-bar/icon.back
 export class TalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {}> {
   static navigationOptions = ({ navigation }) => {
     const { talk } = navigation.state.params
+    const titleMargin = Platform.OS === "ios" ? -50 : 0
     return {
       headerStyle: {
         backgroundColor: palette.portGore,
@@ -88,7 +89,12 @@ export class TalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {
       headerBackImage: backImage,
       headerTintColor: palette.shamrock,
       title: `${format(talk.startTime, "h:mm")} - ${format(talk.endTime, "h:mm")}`,
-      headerTitleStyle: { textAlign: "left", fontWeight: "500", width: "100%", marginLeft: -50 },
+      headerTitleStyle: {
+        textAlign: "left",
+        fontWeight: "500",
+        width: "100%",
+        marginLeft: titleMargin,
+      },
     }
   }
 
@@ -101,7 +107,7 @@ export class TalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {
   }
 
   renderContent = () => {
-    const { talkType } = this.props.navigation.state.params.talk
+    const { talkType = "" } = this.props.navigation.state.params.talk
     switch (talkType.toLowerCase()) {
       case "talk":
         return this.renderTalk()


### PR DESCRIPTION
This fixes https://trello.com/c/FK1zUgVG/34-android-talk-details-time-in-title-is-partially-obscured

I just adjusted the margin on the header title to be platform specific. 

In the course of testing, I also noticed a couple of other minor things which I fixed.

- There was a yellow box about array boundaries which I fixed by not calling `[0]` on the array unless we verify the length is > 0. 
- I encountered a redbox error when `talkType` was null (presumably due to timing issues), so I added a default value

![screenshot_1530221085](https://user-images.githubusercontent.com/6894653/42061613-b2f5b58a-7adf-11e8-88c5-262033afed36.png)
