### PR TITLE
Ensure menu items wrap on Android

### DIFF
--- a/src/views/screens/talk-details/talk-details-screen.tsx
+++ b/src/views/screens/talk-details/talk-details-screen.tsx
@@ -68,6 +68,7 @@ const AFTER_PARTY_DESCRIPTION: TextStyle = { marginTop: spacing.large }
 const MENU_ITEM: ViewStyle = {
   flexDirection: "row",
   marginBottom: spacing.large,
+  width: "100%",
 }
 
 const MENU_ITEM_TEXT: TextStyle = { color: palette.white }
@@ -174,7 +175,7 @@ export class TalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {
         {sponsor && this.renderSponsored(sponsor)}
         <Text text={description} preset="body" style={DESCRIPTION} />
         <Text preset="sectionHeader" tx="talkDetailsScreen.menuTitle" style={LABEL} />
-        {menuItems.map(item => this.renderMenuItem(item))}
+        {menuItems.map((item, index) => this.renderMenuItem(item, index))}
       </View>
     )
   }
@@ -224,9 +225,9 @@ export class TalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {
     )
   }
 
-  renderMenuItem = item => {
+  renderMenuItem = (item, index) => {
     return (
-      <View style={MENU_ITEM}>
+      <View key={index} style={MENU_ITEM}>
         <View style={BULLET} />
         <Text preset="subheader" text={item} style={MENU_ITEM_TEXT} />
       </View>


### PR DESCRIPTION
This fixes https://trello.com/c/gOZuBkL6/35-android-talk-details-menu-items-do-not-wrap

Also got rid of a yellow-box complaining about a mapped list needing unique keys. 

![screenshot_1530223826](https://user-images.githubusercontent.com/6894653/42063993-43cf93e2-7ae9-11e8-839f-265914f9bd0b.png)
