### PR TITLE
Handle > 2 name parts in speaker image

### DIFF
--- a/src/views/screens/talk-details/speaker-image/speaker-image.tsx
+++ b/src/views/screens/talk-details/speaker-image/speaker-image.tsx
@@ -51,13 +51,16 @@ export class SpeakerImage extends React.Component<SpeakerImageProps, {}> {
   render() {
     const { name, employer, image } = this.props.speaker
     const splitName = name.split(" ")
+    const lastIndex = splitName.length - 1
+    const firstPart = splitName.slice(0, lastIndex).join(" ")
+    const secondPart = splitName[lastIndex]
     const key = `${splitName.join("-")}-image`
     return (
       <View key={key} style={ROOT}>
         <Image source={{ uri: image }} style={SPEAKER_IMAGE} />
         <View style={NAME}>
-          <Text text={splitName[0].toUpperCase()} preset="body" style={SPEAKER_NAME} />
-          <Text text={splitName[1].toUpperCase()} preset="body" style={SPEAKER_NAME} />
+          <Text text={firstPart.toUpperCase()} preset="body" style={SPEAKER_NAME} />
+          <Text text={secondPart.toUpperCase()} preset="body" style={SPEAKER_NAME} />
           <Text text={employer} preset="input" style={EMPLOYER} />
         </View>
       </View>


### PR DESCRIPTION
Fixes https://trello.com/c/3c1aaVQO/36-talk-details-speaker-name-cut-off

![simulator screen shot - iphone 6 - 2018-06-28 at 15 52 22](https://user-images.githubusercontent.com/6894653/42064716-30a6e3c6-7aec-11e8-9bfe-1e477b8f6850.png)
![screenshot_1530226921](https://user-images.githubusercontent.com/6894653/42064809-9b9bf874-7aec-11e8-982d-a72d18c037c2.png)
