### PR TITLE
fix tab bar icons being cut off

### DIFF
--- a/src/views/shared/tab-bar/tab-bar.tsx
+++ b/src/views/shared/tab-bar/tab-bar.tsx
@@ -22,6 +22,7 @@ const CONTAINER: ViewStyle = {
   flexDirection: "row",
   justifyContent: "center",
   minHeight: 49,
+  paddingBottom: spacing.tiny,
 }
 
 const TAB: ViewStyle = {
@@ -36,7 +37,7 @@ const ICON_WRAPPER: ViewStyle = {
   alignItems: "center",
   flexGrow: 1,
   justifyContent: "center",
-  marginBottom: 4,
+  minHeight: 26,
 }
 
 const ICON: ViewStyle = {

--- a/test/__snapshots__/storyshots.test.ts.snap
+++ b/test/__snapshots__/storyshots.test.ts.snap
@@ -11018,6 +11018,7 @@ exports[`Storyshots TabBar Behaviour 1`] = `
                     "flexDirection": "row",
                     "justifyContent": "center",
                     "minHeight": 49,
+                    "paddingBottom": 4,
                   }
                 }
               >
@@ -11057,7 +11058,7 @@ exports[`Storyshots TabBar Behaviour 1`] = `
                         "alignItems": "center",
                         "flexGrow": 1,
                         "justifyContent": "center",
-                        "marginBottom": 4,
+                        "minHeight": 26,
                       }
                     }
                   >
@@ -11147,7 +11148,7 @@ exports[`Storyshots TabBar Behaviour 1`] = `
                         "alignItems": "center",
                         "flexGrow": 1,
                         "justifyContent": "center",
-                        "marginBottom": 4,
+                        "minHeight": 26,
                       }
                     }
                   >
@@ -11237,7 +11238,7 @@ exports[`Storyshots TabBar Behaviour 1`] = `
                         "alignItems": "center",
                         "flexGrow": 1,
                         "justifyContent": "center",
-                        "marginBottom": 4,
+                        "minHeight": 26,
                       }
                     }
                   >


### PR DESCRIPTION
## Stories
https://trello.com/c/MA6sH3rI/39-android-tab-bar-top-of-icons-cut-off

## Demos
<img width="266" alt="image" src="https://user-images.githubusercontent.com/1771152/42065732-790b6ea2-7af1-11e8-9a26-fd489e8da36b.png">
<img width="299" alt="image" src="https://user-images.githubusercontent.com/1771152/42065740-869fcedc-7af1-11e8-83db-f98f05130c55.png">
