### PR TITLE
Fix Attractions width and missing map

### DIFF
--- a/src/views/screens/venue-screen/nearby-attractions/attractions-list/attraction/attraction.tsx
+++ b/src/views/screens/venue-screen/nearby-attractions/attractions-list/attraction/attraction.tsx
@@ -13,6 +13,9 @@ const ROOT: ViewStyle = {
 const NAME_WRAPPER: ViewStyle = {
   flexDirection: "row",
 }
+const TITLE_WRAPPER: ViewStyle = {
+  width: "70%",
+}
 const TITLE: TextStyle = {
   color: palette.white,
 }
@@ -30,11 +33,13 @@ export class Attraction extends React.Component<AttractionProps, {}> {
     return (
       <View style={ROOT}>
         <View style={NAME_WRAPPER}>
-          <Text
-            preset="sectionHeader"
-            text={attraction.properties.place_name.toUpperCase()}
-            style={TITLE}
-          />
+          <View style={TITLE_WRAPPER}>
+            <Text
+              preset="sectionHeader"
+              text={attraction.properties.place_name.toUpperCase()}
+              style={TITLE}
+            />
+          </View>
           <Rating rating={attraction.properties.rating} />
         </View>
         <Text preset="fieldLabel" text={cleanedAddress} style={ADDRESS} />

--- a/src/views/screens/venue-screen/nearby-attractions/nearby-attractions.tsx
+++ b/src/views/screens/venue-screen/nearby-attractions/nearby-attractions.tsx
@@ -1,13 +1,15 @@
 import * as React from "react"
-import { View, ViewStyle, TextStyle } from "react-native"
+import { View, ViewStyle, TextStyle, Dimensions } from "react-native"
 import { Text } from "../../../shared/text"
 import { spacing } from "../../../../theme/spacing"
 import { palette } from "../../../../theme/palette"
 import { AttractionsList } from "./attractions-list"
 import { AttractionsMap } from "./attractions-map"
 
+const SCREEN_WIDTH = Dimensions.get("window").width
+
 const ROOT: ViewStyle = {
-  width: "100%",
+  width: SCREEN_WIDTH,
   paddingTop: spacing.large,
   backgroundColor: palette.portGoreLight,
 }

--- a/test/__snapshots__/storyshots.test.ts.snap
+++ b/test/__snapshots__/storyshots.test.ts.snap
@@ -114,21 +114,29 @@ exports[`Storyshots Attraction Props 1`] = `
                   }
                 }
               >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
+                <View
                   style={
                     Object {
-                      "color": "#ffffff",
-                      "fontFamily": "Gotham Rounded",
-                      "fontSize": 14,
-                      "lineHeight": 17,
+                      "width": "70%",
                     }
                   }
                 >
-                  COURIER COFFEE
-                </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#ffffff",
+                        "fontFamily": "Gotham Rounded",
+                        "fontSize": 14,
+                        "lineHeight": 17,
+                      }
+                    }
+                  >
+                    COURIER COFFEE
+                  </Text>
+                </View>
                 <View
                   style={
                     Object {
@@ -523,21 +531,29 @@ exports[`Storyshots AttractionsList Props 1`] = `
                       }
                     }
                   >
-                    <Text
-                      accessible={true}
-                      allowFontScaling={true}
-                      ellipsizeMode="tail"
+                    <View
                       style={
                         Object {
-                          "color": "#ffffff",
-                          "fontFamily": "Gotham Rounded",
-                          "fontSize": 14,
-                          "lineHeight": 17,
+                          "width": "70%",
                         }
                       }
                     >
-                      VOODOO DOUGHNUT
-                    </Text>
+                      <Text
+                        accessible={true}
+                        allowFontScaling={true}
+                        ellipsizeMode="tail"
+                        style={
+                          Object {
+                            "color": "#ffffff",
+                            "fontFamily": "Gotham Rounded",
+                            "fontSize": 14,
+                            "lineHeight": 17,
+                          }
+                        }
+                      >
+                        VOODOO DOUGHNUT
+                      </Text>
+                    </View>
                     <View
                       style={
                         Object {
@@ -631,21 +647,29 @@ Portland, OR 97204
                       }
                     }
                   >
-                    <Text
-                      accessible={true}
-                      allowFontScaling={true}
-                      ellipsizeMode="tail"
+                    <View
                       style={
                         Object {
-                          "color": "#ffffff",
-                          "fontFamily": "Gotham Rounded",
-                          "fontSize": 14,
-                          "lineHeight": 17,
+                          "width": "70%",
                         }
                       }
                     >
-                      SALT & STRAW
-                    </Text>
+                      <Text
+                        accessible={true}
+                        allowFontScaling={true}
+                        ellipsizeMode="tail"
+                        style={
+                          Object {
+                            "color": "#ffffff",
+                            "fontFamily": "Gotham Rounded",
+                            "fontSize": 14,
+                            "lineHeight": 17,
+                          }
+                        }
+                      >
+                        SALT & STRAW
+                      </Text>
+                    </View>
                     <View
                       style={
                         Object {
@@ -739,21 +763,29 @@ Portland, OR 97210
                       }
                     }
                   >
-                    <Text
-                      accessible={true}
-                      allowFontScaling={true}
-                      ellipsizeMode="tail"
+                    <View
                       style={
                         Object {
-                          "color": "#ffffff",
-                          "fontFamily": "Gotham Rounded",
-                          "fontSize": 14,
-                          "lineHeight": 17,
+                          "width": "70%",
                         }
                       }
                     >
-                      TASTY N' ALDER
-                    </Text>
+                      <Text
+                        accessible={true}
+                        allowFontScaling={true}
+                        ellipsizeMode="tail"
+                        style={
+                          Object {
+                            "color": "#ffffff",
+                            "fontFamily": "Gotham Rounded",
+                            "fontSize": 14,
+                            "lineHeight": 17,
+                          }
+                        }
+                      >
+                        TASTY N' ALDER
+                      </Text>
+                    </View>
                     <View
                       style={
                         Object {
@@ -847,21 +879,29 @@ Portland, OR 97205
                       }
                     }
                   >
-                    <Text
-                      accessible={true}
-                      allowFontScaling={true}
-                      ellipsizeMode="tail"
+                    <View
                       style={
                         Object {
-                          "color": "#ffffff",
-                          "fontFamily": "Gotham Rounded",
-                          "fontSize": 14,
-                          "lineHeight": 17,
+                          "width": "70%",
                         }
                       }
                     >
-                      LITTLE BIG BURGER
-                    </Text>
+                      <Text
+                        accessible={true}
+                        allowFontScaling={true}
+                        ellipsizeMode="tail"
+                        style={
+                          Object {
+                            "color": "#ffffff",
+                            "fontFamily": "Gotham Rounded",
+                            "fontSize": 14,
+                            "lineHeight": 17,
+                          }
+                        }
+                      >
+                        LITTLE BIG BURGER
+                      </Text>
+                    </View>
                     <View
                       style={
                         Object {


### PR DESCRIPTION
## Overview

This fixes https://trello.com/c/qcdKHbKW/37-android-venue-attractions-isnt-full-width and as a side effect, also fixes https://trello.com/c/Fa6rXYb1/38-android-venue-map-is-awol

I'm really not sure why `width: "100%"` wasn't doing what it's supposed to. I wouldn't usually resort to finding the screen width using `Dimensions`, but it worked in this case, so I went with it since nothing else seemed to. There was a text wrapping issue with the attraction titles that I noticed once got it to full width which I also fixed. 

Once the width was fixed, it brought the map back on both platforms 🤷‍♀️ 

## Screenshots

![screenshot_1530229406](https://user-images.githubusercontent.com/6894653/42066001-261fd96a-7af3-11e8-9a4c-69982dbaa13c.png)
![screenshot_1530229866](https://user-images.githubusercontent.com/6894653/42066062-77060fca-7af3-11e8-8f3b-ce5f63e76277.png)

![simulator screen shot - iphone 6 - 2018-06-28 at 16 31 02](https://user-images.githubusercontent.com/6894653/42066021-4088a444-7af3-11e8-89e9-758d1695b6b5.png)
![simulator screen shot - iphone 6 - 2018-06-28 at 16 30 49](https://user-images.githubusercontent.com/6894653/42066027-4968d610-7af3-11e8-91cc-1b2eb7abe1c1.png)

