### PR TITLE
Add actual AWS key to .env on CI server

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "npm-run-all lint:*",
     "lint:ts": "tslint -p .",
     "ci:test": "yarn test --ci",
-    "ci:setup": "cp .sample.env .env",
+    "ci:setup": "touch .env && echo \"AWS_APPSYNC_API_KEY=\"$AWS_APPSYNC_API_KEY >> .env",
     "postinstall": "test -n \"$NOYARNPOSTINSTALL\" || solidarity",
     "precommit": "lint-staged",
     "prepare": "patch-package",


### PR DESCRIPTION
Apparently, the key actually needs to be in .env for the app to not crash when loading the chat screen. 

The key is setup as an ENV variable on the CI server already, this just copies it to `.env`. Previously, we were pulling it directly from `process.env`. 