### PR TITLE
Update copy for 2019 and fix back button bug

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -15,8 +15,8 @@
   },
   "welcomeScreen": {
     "header1": "Welcome to",
-    "header2": "Chain React 2018",
-    "subtitle": "We've rebuilt our app to make it easier to view the schedule, explore the city, and access need-to-know details!",
+    "header2": "Chain React 2019",
+    "subtitle": "Use our app to to view the schedule, explore the city, and access need-to-know details! You can even chat with others about each talk, right here in the app!",
     "nextScreenButton": "I'm Ready!"
   },
   "profilescreen": {
@@ -48,7 +48,7 @@
     "title": "Explore",
     "gerdingTheater": {
       "title": "THE ARMORY\nIN PORTLAND",
-      "description": "Join us in historic, diverse downtown Portland for this year’s Chain React Conference! We’ll kick off on July 11th with a hands-on, two-track workshop at the Benson Hotel, continuing at the Gerding Theater at the Armory on the 12th and 13th."
+      "description": "Join us in historic, diverse downtown Portland for this year’s Chain React Conference! We’ll kick off on July 10th with a hands-on, two-track workshop at the Benson Hotel, continuing at the Gerding Theater at the Armory on the 11th and 12th."
     },
     "gettingToChainReact": {
       "title1": "PORTLAND GUIDE",

--- a/app/screens/schedule-screen/schedule-screen.tsx
+++ b/app/screens/schedule-screen/schedule-screen.tsx
@@ -50,6 +50,7 @@ export class ScheduleScreen extends React.Component<
   }
   static navigationOptions = {
     header: null,
+    headerBackTitle: null,
     // Header Style is necessary to prevent ugly white header when navigating back to this screen from a child screen
     headerStyle: {
       backgroundColor: color.palette.portGore,

--- a/app/screens/talk-details/talk-details-screen.tsx
+++ b/app/screens/talk-details/talk-details-screen.tsx
@@ -94,6 +94,10 @@ const MENU_ITEM: ViewStyle = {
   width: "100%",
 }
 
+const BACK_BUTTON: ViewStyle = {
+  paddingHorizontal: spacing.small,
+}
+
 const MENU_ITEM_TEXT: TextStyle = { color: palette.white }
 
 const TAB_HOLDER: ViewStyle = { flex: 1 }
@@ -125,7 +129,7 @@ export interface NavigationStateParams {
 export interface TalkDetailsScreenProps extends NavigationScreenProps<NavigationStateParams> {}
 
 const backImage = () => (
-  <View hitSlop={HIT_SLOP}>
+  <View style={BACK_BUTTON} hitSlop={HIT_SLOP}>
     <Image source={require("../../components/title-bar/icon.back-arrow.png")} />
   </View>
 )

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
+    "adb": "adb reverse tcp:9090 tcp:9090 && adb reverse tcp:3000 tcp:3000 && adb reverse tcp:9001 tcp:9001 && adb reverse tcp:8081 tcp:8081",
     "test": "NODE_ENV=test TZ=America/Los_Angeles jest",
     "compile": "tsc --noEmit -p . --pretty",
     "format": "npm-run-all format:*",


### PR DESCRIPTION
Some copy was outdated or explicitly referenced the 2018 conference dates, so I updated that.

Also fixed a bug where the back button text was overlapping the time and the padding was off. I think this was a side effect of the react-navigation upgrade. (Fixes #65)

<img width="466" alt="Screen Shot 2019-06-05 at 1 04 32 PM" src="https://user-images.githubusercontent.com/6894653/58988691-1134df80-8797-11e9-8ec7-eb093e9a1fa5.png">
