### PR TITLE
Fix layout bugs

### DIFF
--- a/app/navigation/main-navigator.tsx
+++ b/app/navigation/main-navigator.tsx
@@ -7,7 +7,7 @@ import { TalkDetailsScreen } from "../screens/talk-details"
 import { ProfileScreen } from "../screens/profile-screen"
 import { CodeOfConductScreen } from "../screens/code-of-conduct"
 import { TabIcon } from "../components/tab-icon"
-import { color, palette } from "../theme"
+import { color, palette, spacing } from "../theme"
 
 export const MainNavigator = createStackNavigator(
   {
@@ -50,6 +50,8 @@ export const MainNavigator = createStackNavigator(
           tabBarOptions: {
             style: {
               backgroundColor: color.tabbar,
+              height: 56,
+              paddingVertical: spacing.tiny,
             },
             activeTintColor: palette.white,
           },

--- a/app/screens/info-screen/info-screen.tsx
+++ b/app/screens/info-screen/info-screen.tsx
@@ -13,20 +13,19 @@ import { Photobomb } from "../../components/photobomb/photobomb"
 export interface InfoScreenProps extends NavigationScreenProps<{}> {}
 
 const TITLE: TextStyle = {
-  marginLeft: spacing.large,
-}
-const ROOT: ViewStyle = {
   marginTop: spacing.extraLarge,
+  marginLeft: spacing.large,
 }
 
 export class InfoScreen extends React.Component<InfoScreenProps, {}> {
   static navigationOptions = {
     header: null,
+    headerBackTitle: null,
   }
 
   render() {
     return (
-      <Screen style={ROOT} preset="scrollStack" backgroundColor={palette.portGore}>
+      <Screen preset="scrollStack" backgroundColor={palette.portGore}>
         <Text preset="title" tx="infoScreen.title" style={TITLE} />
         <WiFi />
         <Conduct onPress={() => this.props.navigation.navigate("codeOfConduct")} />

--- a/ios/ChainReactConf.xcodeproj/project.pbxproj
+++ b/ios/ChainReactConf.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -1961,7 +1960,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = infinitered.stage.ChainReactConf;
 				PRODUCT_NAME = ChainReactConf;
 				PROVISIONING_PROFILE = "d63749b1-a778-4ccd-97cc-2690705c5dab";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development infinitered.stage.ChainReactConf 1530133221";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development infinitered.stage.ChainReactConf";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};


### PR DESCRIPTION
Fixes a couple small layout bugs: #74 and #76 

Also generated a new Development provisioning profile, so if you're working locally and you need to run on a device, make sure to run `fastlane match development`

<img width="470" alt="Screen Shot 2019-06-10 at 5 57 19 PM" src="https://user-images.githubusercontent.com/6894653/59283558-a0bb1200-8c1f-11e9-95d0-e15944f32be5.png">
<img width="481" alt="Screen Shot 2019-06-10 at 5 57 33 PM" src="https://user-images.githubusercontent.com/6894653/59283559-a0bb1200-8c1f-11e9-96a6-02e033235a21.png">


