### PR TITLE
Recalculate screen dimensions with each render

### DIFF
--- a/app/components/attractions-list/attractions-list.tsx
+++ b/app/components/attractions-list/attractions-list.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { View, TouchableOpacity, ViewStyle, TextStyle } from "react-native"
 import { Text } from "../text"
-import { palette, spacing } from "../../theme"
+import { palette, spacing, getScreenHeight, getScreenWidth } from "../../theme"
 import { Attraction } from "../attraction"
 const nearbyAttractionsData = require("../nearby-attractions/nearby-attractions.data.json")
 
@@ -10,7 +10,6 @@ export interface AttractionsListState {
 }
 
 const ROOT: ViewStyle = {
-  width: "100%",
   flex: 1,
   paddingHorizontal: 17,
   paddingBottom: spacing.large + spacing.small,
@@ -41,7 +40,7 @@ export class AttractionsList extends React.Component<{}, AttractionsListState> {
   render() {
     const { selectedType } = this.state
     return (
-      <View style={ROOT}>
+      <View style={{ ...ROOT, ...{ width: getScreenWidth() } }}>
         <View style={NAV}>
           <TouchableOpacity
             style={NAV_ITEM}

--- a/app/components/attractions-map-callout/attractions-map-callout.tsx
+++ b/app/components/attractions-map-callout/attractions-map-callout.tsx
@@ -10,7 +10,7 @@ import {
   Linking,
 } from "react-native"
 import { Text } from "../text"
-import { color, spacing, SCREEN_WIDTH } from "../../theme"
+import { color, spacing, getScreenWidth } from "../../theme"
 import { CLOSE_ICON } from "./"
 
 export interface AttractionsMapCalloutProps {
@@ -26,7 +26,6 @@ const CALLOUT_CONTAINER: ViewStyle = {
 }
 
 const CALLOUT_CONTENT_CONTAINER: ViewStyle = {
-  width: SCREEN_WIDTH * 0.9,
   padding: spacing.large,
   backgroundColor: color.callout,
   shadowColor: color.calloutShadow,
@@ -112,10 +111,13 @@ export class AttractionsMapCallout extends React.Component<AttractionsMapCallout
   }
 
   render() {
+    const widthStyle = {
+      width: getScreenWidth() * 0.9,
+    }
     return (
       <Mapbox.Callout>
         <View style={CALLOUT_CONTAINER}>
-          <View style={CALLOUT_CONTENT_CONTAINER}>
+          <View style={{ ...CALLOUT_CONTENT_CONTAINER, ...widthStyle }}>
             <View style={CALLOUT_INFO}>
               <Text style={TITLE} text={this.props.title.toUpperCase()} />
               <Text style={DESCRIPTION} text={this.props.description} />

--- a/app/components/attractions-map/attractions-map.tsx
+++ b/app/components/attractions-map/attractions-map.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import Mapbox from "@mapbox/react-native-mapbox-gl"
-import { View, ViewStyle, TouchableWithoutFeedback, Dimensions } from "react-native"
+import { View, ViewStyle, TouchableWithoutFeedback } from "react-native"
 import { AttractionsMapCallout } from "../attractions-map-callout"
-import { color } from "../../theme"
+import { color, getScreenWidth, getScreenHeight } from "../../theme"
 import { unnest } from "ramda"
 const nearbyAttractionsData = require("../nearby-attractions/nearby-attractions.data.json")
 
@@ -15,10 +15,8 @@ export interface AttractionsMapState {
 }
 
 const MAPVIEW: ViewStyle = {
-  width: "100%",
   height: 506,
   flex: 1,
-  maxHeight: Dimensions.get("window").height * 0.8,
 }
 
 const HIDDEN_MARKER: ViewStyle = { backgroundColor: color.transparent }
@@ -61,13 +59,14 @@ export class AttractionsMap extends React.Component<{}, AttractionsMapState> {
   }
 
   render() {
+    const size = { width: getScreenWidth(), maxHeight: getScreenHeight() * 0.8 }
     return (
       <Mapbox.MapView
         centerCoordinate={nearbyAttractionsData.locations[0].geometry.coordinates}
         rotateEnabled={false}
         pitchEnabled={false}
         styleURL="mapbox://styles/jhuskey/cjabpqolp3lf02so534xe4q9g"
-        style={MAPVIEW}
+        style={{ ...MAPVIEW, ...size }}
         // showUserLocation
       >
         {unnest(

--- a/app/components/nearby-attractions/nearby-attractions.tsx
+++ b/app/components/nearby-attractions/nearby-attractions.tsx
@@ -1,21 +1,21 @@
 import * as React from "react"
-import { View, ViewStyle, Dimensions } from "react-native"
-import { palette, spacing } from "../../theme"
+import { View, ViewStyle } from "react-native"
+import { palette, spacing, getScreenWidth } from "../../theme"
 import { AttractionsList } from "../attractions-list"
 import { AttractionsMap } from "../attractions-map"
 
-const SCREEN_WIDTH = Dimensions.get("window").width
-
 const ROOT: ViewStyle = {
-  width: SCREEN_WIDTH,
   paddingTop: spacing.large,
   backgroundColor: palette.portGoreLight,
 }
 
 export class NearbyAttractions extends React.Component<{}, {}> {
   render() {
+    const fullWidth = {
+      width: getScreenWidth(),
+    }
     return (
-      <View style={ROOT}>
+      <View style={{ ...ROOT, ...fullWidth }}>
         <AttractionsList />
         <AttractionsMap />
       </View>

--- a/app/components/presented-by/presented-by.presets.ts
+++ b/app/components/presented-by/presented-by.presets.ts
@@ -6,7 +6,6 @@ import { spacing } from "../../theme"
  */
 const BASE_VIEW: ViewStyle = {
   flex: 1,
-  width: "100%",
   justifyContent: "center",
   marginTop: spacing.ginormous + spacing.large,
   paddingHorizontal: spacing.large,

--- a/app/components/presented-by/presented-by.tsx
+++ b/app/components/presented-by/presented-by.tsx
@@ -1,18 +1,14 @@
 import * as React from "react"
-import { View, Image, ViewStyle, ImageStyle, TextStyle, Dimensions } from "react-native"
+import { View, Image, ViewStyle, ImageStyle, TextStyle } from "react-native"
 import { presentedByPresets } from "./presented-by.presets"
 import { PresentedByProps } from "./presented-by.props"
 import { Text } from "../text"
 import { SocialButton } from "../social-button"
-import { spacing, palette } from "../../theme"
-
-const SCREEN_WIDTH = Dimensions.get("window").width
-const MAX_WIDTH = SCREEN_WIDTH - 2 * spacing.large
+import { spacing, palette, getScreenWidth } from "../../theme"
 
 const BACKGROUND: ImageStyle = {
   position: "absolute",
   bottom: 0,
-  width: "100%",
   alignSelf: "center",
 }
 const TEXT: TextStyle = {
@@ -39,7 +35,6 @@ const SOCIAL_WRAPPER: ViewStyle = {
   alignItems: "center",
   marginTop: 40,
   marginBottom: 107,
-  maxWidth: MAX_WIDTH,
   flexWrap: "wrap",
 }
 const SOCIAL_BUTTON: ViewStyle = {
@@ -64,22 +59,29 @@ export const linkPresets = {
 export function PresentedBy(props: PresentedByProps) {
   // grab the props
   const { ...rest } = props
+  const fullWidth = {
+    width: getScreenWidth(),
+  }
 
   // assemble the style
   const viewPresetToUse = presentedByPresets.default
 
-  const viewStyle = { ...viewPresetToUse }
+  const viewStyle = { ...viewPresetToUse, ...fullWidth }
+
+  const widthStyle = {
+    maxWidth: getScreenWidth() - 2 * spacing.large,
+  }
 
   return (
     <View>
-      <Image style={BACKGROUND} source={backgroundImage} />
+      <Image style={{ ...BACKGROUND, ...fullWidth }} source={backgroundImage} />
       <View style={viewStyle} {...rest}>
         <Text preset="header" tx="infoScreen.presentedBy.title" style={TITLE} />
         <Text preset="header" tx="infoScreen.presentedBy.subtitle" style={SUBTITLE} />
         <Text preset="body" style={BIO} tx="infoScreen.presentedBy.bio" />
         <View style={FOOTER}>
           <Image style={LOGO} source={infiniteRedLogo} />
-          <View style={SOCIAL_WRAPPER}>
+          <View style={{ ...SOCIAL_WRAPPER, ...widthStyle }}>
             <SocialButton preset="website" link={linkPresets.website} style={SOCIAL_BUTTON} />
             <SocialButton preset="twitter" link={linkPresets.twitter} style={SOCIAL_BUTTON} />
             <SocialButton preset="github" link={linkPresets.github} style={SOCIAL_BUTTON} />

--- a/app/components/speaker-bio/speaker-bio.tsx
+++ b/app/components/speaker-bio/speaker-bio.tsx
@@ -1,19 +1,15 @@
 import * as React from "react"
-import { View, ViewStyle, TextStyle, Dimensions } from "react-native"
+import { View, ViewStyle, TextStyle } from "react-native"
 import { Text } from "../text"
 import { SocialButton } from "../social-button"
-import { palette, spacing } from "../../theme"
+import { palette, spacing, getScreenWidth } from "../../theme"
 
 export interface SpeakerBioProps {
   speaker: any
   last?: boolean
 }
 
-const SCREEN_WIDTH = Dimensions.get("window").width
-const MAX_WIDTH = SCREEN_WIDTH - 2 * spacing.large
-
 const ROOT: ViewStyle = {
-  width: "100%",
   marginTop: spacing.extraLarge + spacing.large,
 }
 
@@ -26,7 +22,6 @@ const SOCIAL_WRAPPER: ViewStyle = {
   flex: 1,
   flexDirection: "row",
   marginTop: spacing.large,
-  maxWidth: MAX_WIDTH,
   flexWrap: "wrap",
 }
 
@@ -59,7 +54,10 @@ export class SpeakerBio extends React.Component<SpeakerBioProps, {}> {
       dribbble,
       websites: websites || [],
     }
-    const socialStyles = [SOCIAL_WRAPPER, last && SOCIAL_WRAPPER_LAST]
+    const widthStyles = {
+      maxWidth: getScreenWidth() - 2 * spacing.large,
+    }
+    const socialStyles = [{ ...SOCIAL_WRAPPER, ...widthStyles }, last && SOCIAL_WRAPPER_LAST]
 
     if (
       facebook ||
@@ -74,7 +72,7 @@ export class SpeakerBio extends React.Component<SpeakerBioProps, {}> {
       const lastIndex = splitName.length - 1
       const firstName = splitName.slice(0, lastIndex).join(" ")
       return (
-        <View key={key} style={ROOT}>
+        <View key={key} style={{ ...ROOT, ...{ width: 0.9 * getScreenWidth() } }}>
           <Text
             text={`${bio ? "ABOUT" : "FOLLOW"} ${firstName.toUpperCase()}`}
             preset="sectionHeader"

--- a/app/components/speaker-image/speaker-image.tsx
+++ b/app/components/speaker-image/speaker-image.tsx
@@ -1,13 +1,10 @@
 import * as React from "react"
-import { View, ViewStyle, Image, ImageStyle, TextStyle, Dimensions } from "react-native"
+import { View, ViewStyle, Image, ImageStyle, TextStyle } from "react-native"
 import { Text } from "../text"
-import { palette, spacing } from "../../theme"
+import { palette, spacing, getScreenWidth } from "../../theme"
 
 // Image size math
-const SCREEN_WIDTH = Dimensions.get("window").width
-const IMAGE_WIDTH = 0.92 * (SCREEN_WIDTH - 2 * spacing.large) // 95% of the available container, screen width minus twice the screen padding.
 const IMAGE_ASPECT_RATIO = 0.77 // This is the original aspect ratio of all the speaker images as they come from the server, which are 292 x 380.
-const IMAGE_HEIGHT = IMAGE_WIDTH / IMAGE_ASPECT_RATIO
 
 export interface SpeakerImageProps {
   speaker: any
@@ -19,8 +16,6 @@ const ROOT: ViewStyle = {
 }
 
 const SPEAKER_IMAGE: ImageStyle = {
-  width: IMAGE_WIDTH,
-  height: IMAGE_HEIGHT,
   marginRight: 32,
 }
 
@@ -50,10 +45,19 @@ export class SpeakerImage extends React.Component<SpeakerImageProps, {}> {
     const firstPart = splitName.slice(0, lastIndex).join(" ")
     const secondPart = splitName[lastIndex]
     const key = `${splitName.join("-")}-image`
+    // Image size math
+    const imageWidth = 0.92 * (getScreenWidth() - 2 * spacing.large) // 95% of the available container, screen width minus twice the screen padding.
+    const imageHeight = imageWidth / IMAGE_ASPECT_RATIO
+    const speakerImageWidthStyles = {
+      height: imageHeight,
+      width: imageWidth,
+    }
 
     return (
       <View key={key} style={ROOT}>
-        {image && <Image source={{ uri: image }} style={SPEAKER_IMAGE} />}
+        {image && (
+          <Image source={{ uri: image }} style={{ ...SPEAKER_IMAGE, ...speakerImageWidthStyles }} />
+        )}
         <View style={NAME}>
           <Text text={firstPart.toUpperCase()} preset="body" style={SPEAKER_NAME} />
           <Text text={secondPart.toUpperCase()} preset="body" style={SPEAKER_NAME} />

--- a/app/screens/talk-details/talk-details-screen.tsx
+++ b/app/screens/talk-details/talk-details-screen.tsx
@@ -7,7 +7,6 @@ import {
   Image,
   ViewStyle,
   TextStyle,
-  Dimensions,
   ImageStyle,
   Platform,
   AsyncStorage,
@@ -18,7 +17,7 @@ import Amplify, { API, graphqlOperation } from "aws-amplify"
 import { format } from "date-fns"
 import uuid from "uuid/v4"
 import { Screen } from "../../components/screen"
-import { palette, spacing } from "../../theme"
+import { palette, spacing, getScreenWidth } from "../../theme"
 import { Text } from "../../components/text"
 import { SpeakerImage } from "../../components/speaker-image"
 import { TalkTitle } from "../../components//talk-title"
@@ -42,13 +41,8 @@ const FULL_SIZE: ViewStyle = {
   height: "100%",
 }
 
-const SCREEN_WIDTH = Dimensions.get("window").width
-const IMAGE_WIDTH = SCREEN_WIDTH - 2 * spacing.large
 const IMAGE_ASPECT_RATIO = 1.5
-const IMAGE_HEIGHT = IMAGE_WIDTH / IMAGE_ASPECT_RATIO
 const FULL_WIDTH_IMAGE: ImageStyle = {
-  width: IMAGE_WIDTH,
-  height: IMAGE_HEIGHT,
   resizeMode: "contain",
 }
 
@@ -110,7 +104,7 @@ const COMMENT_CONTAINER = { paddingVertical: 15, marginBottom: 50 }
 const COMMENT_STYLE = { paddingHorizontal: 20, marginBottom: 20 }
 const CREATED_BY = { color: "white", fontWeight: "600" }
 const CREATED_AT = { color: "rgba(255, 255, 255, .5)", fontSize: 11, marginLeft: 8, marginTop: 3 }
-const INPUT_CONTAINER = { bottom: 0, position: "absolute", left: 0, width: SCREEN_WIDTH }
+const INPUT_CONTAINER = { bottom: 0, position: "absolute", left: 0 }
 const MESSAGE_INPUT = { backgroundColor: "white", height: 50, paddingHorizontal: 8 }
 
 const HIT_SLOP = {
@@ -219,11 +213,23 @@ class BaseTalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {}> 
   render() {
     const { talkType = "" } = this.props.navigation.state.params.talk
     let { comments } = this.props
+    // Image size math
+    const imageWidth = 0.92 * (getScreenWidth() - 2 * spacing.large) // 95% of the available container, screen width minus twice the screen padding.
+    const imageHeight = imageWidth / IMAGE_ASPECT_RATIO
+    const speakerImageWidthStyles = {
+      height: imageHeight,
+      width: imageWidth,
+    }
+    const widthStyles = {
+      width: getScreenWidth(),
+    }
+
     comments = comments
       .sort(function(a, b) {
         return new Date(b.createdAt) - new Date(a.createdAt)
       })
       .reverse()
+
     return (
       <View style={MAIN_CONTAINER}>
         {(talkType === "TALK" || talkType === "WORKSHOP") && (
@@ -255,7 +261,7 @@ class BaseTalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {}> 
                 ))}
               </View>
             </ScrollView>
-            <View style={INPUT_CONTAINER}>
+            <View style={{ ...INPUT_CONTAINER, ...widthStyles }}>
               <TextInput
                 onChangeText={v => this.setState({ inputValue: v })}
                 style={MESSAGE_INPUT}
@@ -348,9 +354,19 @@ class BaseTalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {}> 
       title,
       image,
     } = this.props.navigation.state.params.talk
+    // Image size math
+    const imageWidth = 0.92 * (getScreenWidth() - 2 * spacing.large) // 95% of the available container, screen width minus twice the screen padding.
+    const imageHeight = imageWidth / IMAGE_ASPECT_RATIO
+    const speakerImageWidthStyles = {
+      height: imageHeight,
+      width: imageWidth,
+    }
     return (
       <View style={FULL_SIZE}>
-        <Image source={{ uri: image }} style={FULL_WIDTH_IMAGE} />
+        <Image
+          source={{ uri: image }}
+          style={{ ...FULL_WIDTH_IMAGE, ...speakerImageWidthStyles }}
+        />
         <Text text={title} preset="body" style={TITLE} />
         {sponsor && this.renderSponsored(sponsor)}
         <Text text={description} preset="body" style={DESCRIPTION} />

--- a/app/theme/spacing.ts
+++ b/app/theme/spacing.ts
@@ -10,5 +10,5 @@ export const spacing = {
   ginormous: 100,
 }
 
-export const SCREEN_WIDTH = Dimensions.get("window").width
-export const SCREEN_HEIGHT = Dimensions.get("window").width
+export const getScreenWidth = () => Dimensions.get("window").width
+export const getScreenHeight = () => Dimensions.get("window").height

--- a/test/__snapshots__/storyshots.test.ts.snap
+++ b/test/__snapshots__/storyshots.test.ts.snap
@@ -306,7 +306,7 @@ exports[`Storyshots AttractionsList Props 1`] = `
                   "flex": 1,
                   "paddingBottom": 30,
                   "paddingHorizontal": 17,
-                  "width": "100%",
+                  "width": 750,
                 }
               }
             >
@@ -4782,7 +4782,7 @@ exports[`Storyshots PresentedBy Presets 1`] = `
                     "alignSelf": "center",
                     "bottom": 0,
                     "position": "absolute",
-                    "width": "100%",
+                    "width": 750,
                   }
                 }
               />
@@ -4793,7 +4793,7 @@ exports[`Storyshots PresentedBy Presets 1`] = `
                     "justifyContent": "center",
                     "marginTop": 120,
                     "paddingHorizontal": 20,
-                    "width": "100%",
+                    "width": 750,
                   }
                 }
               >


### PR DESCRIPTION
Fixes #77 

Under seemingly inconsistent circumstances, `Dimensions.get("window")` doesn't return accurate values immediately, resulting in incorrect layout if you have saved the result of that call in a constant outside of the `render` function. 

This moves any sort of `Dimension`-based styles inside the `render` function so they will be called at runtime. 