### PR TITLE
Fix/multiple speakers

### DIFF
--- a/app/components/schedule-cell/schedule-cell.tsx
+++ b/app/components/schedule-cell/schedule-cell.tsx
@@ -36,6 +36,7 @@ export class ScheduleCell extends React.Component<ScheduleCellProps, {}> {
     const { preset, index, talk, onPress, noTime } = this.props
     const style: any = ScheduleCellPresets[preset] || ScheduleCellPresets.default
     const isOdd = index % 2 === 0 // index starts at 0
+    const speakerName = talk.speakers.map(s => s.name).join(", ")
     if (!talk) return null
     return (
       <TouchableWithoutFeedback
@@ -56,11 +57,7 @@ export class ScheduleCell extends React.Component<ScheduleCellProps, {}> {
             <View style={style.content as ViewStyle}>
               <Text preset="subheader" text={talk.title} style={style.title as TextStyle} />
               {talk.speakers && talk.speakers.length > 0 && talk.speakers[0].name && (
-                <Text
-                  preset="subheader"
-                  text={talk.speakers[0].name}
-                  style={style.speaker as TextStyle}
-                />
+                <Text preset="subheader" text={speakerName} style={style.speaker as TextStyle} />
               )}
               {preset === "afterparty" && (
                 <Text
@@ -114,7 +111,7 @@ export class ScheduleCell extends React.Component<ScheduleCellProps, {}> {
       if (sponsor === "Bumped") image = require("./images/sponsor-bumped.png")
     } else if (talkTypeLower === "break") {
       image = require("./images/coffee-small.png")
-    } else if (talkTypeLower === "talk" || talkTypeLower === "workshop") {
+    } else if (["talk", "workshop", "welcome", "goodbye"].includes(talkTypeLower)) {
       image = speakers && speakers[0] && speakers[0].image ? { uri: speakers[0].image } : null
     } else if (talkTypeLower === "lunch") {
       image = require("./images/lunch.png")

--- a/app/components/speaker-bio/speaker-bio.tsx
+++ b/app/components/speaker-bio/speaker-bio.tsx
@@ -57,9 +57,7 @@ export class SpeakerBio extends React.Component<SpeakerBioProps, {}> {
     const widthStyles = {
       maxWidth: getScreenWidth() - 2 * spacing.large,
     }
-    const socialStyles = [{ ...SOCIAL_WRAPPER, ...widthStyles }, last && SOCIAL_WRAPPER_LAST]
-
-    if (
+    const displaySocial =
       facebook ||
       twitter ||
       github ||
@@ -67,18 +65,18 @@ export class SpeakerBio extends React.Component<SpeakerBioProps, {}> {
       instagram ||
       dribbble ||
       (websites && websites.length > 0)
-    ) {
-      const splitName = name.split(" ")
-      const lastIndex = splitName.length - 1
-      const firstName = splitName.slice(0, lastIndex).join(" ")
-      return (
-        <View key={key} style={{ ...ROOT, ...{ width: 0.9 * getScreenWidth() } }}>
-          <Text
-            text={`${bio ? "ABOUT" : "FOLLOW"} ${firstName.toUpperCase()}`}
-            preset="sectionHeader"
-            style={{ color: palette.shamrock }}
-          />
-          {bio && <Text text={bio} preset="subheader" style={BIO} />}
+    const socialStyles = [{ ...SOCIAL_WRAPPER, ...widthStyles }, last && SOCIAL_WRAPPER_LAST]
+    const lastIndex = splitName.length - 1
+    const firstName = splitName.slice(0, lastIndex).join(" ")
+    return (
+      <View key={key} style={{ ...ROOT, ...{ width: 0.9 * getScreenWidth() } }}>
+        <Text
+          text={`${bio ? "ABOUT" : "FOLLOW"} ${firstName.toUpperCase()}`}
+          preset="sectionHeader"
+          style={{ color: palette.shamrock }}
+        />
+        {bio && <Text text={bio} preset="subheader" style={BIO} />}
+        {displaySocial ? (
           <View style={socialStyles}>
             {Object.keys(links).map(k => {
               return k === "websites"
@@ -86,11 +84,9 @@ export class SpeakerBio extends React.Component<SpeakerBioProps, {}> {
                 : this.renderLink(k, links[k])
             })}
           </View>
-        </View>
-      )
-    } else {
-      return null
-    }
+        ) : null}
+      </View>
+    )
   }
 
   renderLink = (k, link) => {

--- a/app/components/speaker-image/speaker-image.tsx
+++ b/app/components/speaker-image/speaker-image.tsx
@@ -48,15 +48,17 @@ export class SpeakerImage extends React.Component<SpeakerImageProps, {}> {
     // Image size math
     const imageWidth = 0.92 * (getScreenWidth() - 2 * spacing.large) // 95% of the available container, screen width minus twice the screen padding.
     const imageHeight = imageWidth / IMAGE_ASPECT_RATIO
-    const speakerImageWidthStyles = {
+    const imageDimensions = {
       height: imageHeight,
       width: imageWidth,
     }
 
     return (
       <View key={key} style={ROOT}>
-        {image && (
-          <Image source={{ uri: image }} style={{ ...SPEAKER_IMAGE, ...speakerImageWidthStyles }} />
+        {image ? (
+          <Image source={{ uri: image }} style={{ ...SPEAKER_IMAGE, ...imageDimensions }} />
+        ) : (
+          <View style={{ ...imageDimensions }} />
         )}
         <View style={NAME}>
           <Text text={firstPart.toUpperCase()} preset="body" style={SPEAKER_NAME} />

--- a/app/models/root-store/setup-root-store.ts
+++ b/app/models/root-store/setup-root-store.ts
@@ -15,6 +15,7 @@ const ROOT_STATE_STORAGE_KEY = "root"
  * The uri we'll be using for graphql requests.
  */
 const GRAPHQL_URI = "https://infinite.red/graphql"
+// const GRAPHQL_URI = "http://localhost:4000/graphql"
 
 /**
  * Setup the root state.

--- a/app/screens/schedule-screen/schedule-screen.tsx
+++ b/app/screens/schedule-screen/schedule-screen.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { View, ViewStyle, ScrollView, TextStyle } from "react-native"
+import { View, ViewStyle, ScrollView, TextStyle, RefreshControl } from "react-native"
 import { NavigationScreenProps } from "react-navigation"
 import { Text } from "../../components/text"
 import { Screen } from "../../components/screen"
@@ -39,14 +39,17 @@ interface ScheduleScreenProps extends NavigationScreenProps<{}> {
   talkStore: TalkStore
 }
 
+interface ScheduleScreenState {
+  selected: "wednesday" | "thursday" | "friday"
+  refreshing: boolean
+}
+
 @inject("talkStore")
 @observer
-export class ScheduleScreen extends React.Component<
-  ScheduleScreenProps,
-  { selected: "wednesday" | "thursday" | "friday" }
-> {
+export class ScheduleScreen extends React.Component<ScheduleScreenProps, ScheduleScreenState> {
   state = {
     selected: getSelectedDay(),
+    refreshing: false,
   }
   static navigationOptions = {
     header: null,
@@ -63,11 +66,24 @@ export class ScheduleScreen extends React.Component<
     talkStore && talkStore.getAll()
   }
 
+  refreshData = () => {
+    const { talkStore } = this.props
+    this.setState({ refreshing: true })
+    talkStore && talkStore.getAll()
+    this.setState({ refreshing: false })
+  }
+
   render() {
     const { selected } = this.state
     return (
       <Screen preset="fixed" backgroundColor={color.palette.portGore} style={ROOT}>
-        <ScrollView style={{ flex: 1, width: "100%" }} key={`${selected}-scrollview`}>
+        <ScrollView
+          style={{ flex: 1, width: "100%" }}
+          key={`${selected}-scrollview`}
+          refreshControl={
+            <RefreshControl refreshing={this.state.refreshing} onRefresh={this.refreshData} />
+          }
+        >
           <Text preset="title" tx="scheduleScreen.title" style={TITLE} />
           {selected === "wednesday" ? this.renderWorkshops() : this.renderContent()}
         </ScrollView>

--- a/app/screens/talk-details/talk-details-screen.tsx
+++ b/app/screens/talk-details/talk-details-screen.tsx
@@ -366,6 +366,9 @@ export class TalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {
         return this.renderLunch(imageDimensions)
       case "panel":
         return this.renderPanel(imageDimensions)
+      case "welcome":
+      case "goodbye":
+        return this.renderWelcome()
       case "afterparty":
         return this.renderAfterParty(imageDimensions)
       default:
@@ -387,6 +390,29 @@ export class TalkDetailsScreen extends React.Component<TalkDetailsScreenProps, {
           />
         )}
         {talk.speakers && <SpeakerBio speaker={talk.speakers[0]} />}
+      </View>
+    )
+  }
+
+  renderWelcome = () => {
+    const {
+      talk: { title, description, speakers },
+    } = this.props.navigation.state.params
+    return (
+      <View style={FULL_SIZE}>
+        <Text text={title} preset="body" style={TITLE} />
+        <Text text={description} preset="body" style={DESCRIPTION} />
+        {speakers &&
+          speakers.length &&
+          speakers.map((speaker, index) => {
+            const isLast = index === speakers.length - 1
+            return (
+              <View key={index} style={PANEL_BIO}>
+                <SpeakerImage speaker={speaker} />
+                <SpeakerBio speaker={speaker} last={isLast} />
+              </View>
+            )
+          })}
       </View>
     )
   }


### PR DESCRIPTION
Addresses a few things:

Closes #130 and #138 and #133 

- Displays all speakers names on schedule cell
- Displays photo and bio for all speakers for "welcome" and "goodbye" types
- Fixes an issue were speaker bio wasn't displaying if speaker had no social links
- Adds pull to refresh on the schedule screen

<img width="398" alt="Screen Shot 2019-06-21 at 9 40 10 AM" src="https://user-images.githubusercontent.com/6894653/59939054-8ea15680-940b-11e9-84fa-86b9ae2a6c3c.png">

<img width="429" alt="Screen Shot 2019-06-21 at 9 40 04 AM" src="https://user-images.githubusercontent.com/6894653/59939060-93660a80-940b-11e9-8081-a35efc0be78f.png">
