### PR TITLE
Remove test warnings

### DIFF
--- a/app/components/attraction/attraction.story.tsx
+++ b/app/components/attraction/attraction.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Attraction } from "./attraction"
 
-storiesOf("Attraction")
+storiesOf("Attraction", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Props", () => (
     <Story>

--- a/app/components/attractions-list/attractions-list.story.tsx
+++ b/app/components/attractions-list/attractions-list.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { AttractionsList } from "./attractions-list"
 
-storiesOf("AttractionsList")
+storiesOf("AttractionsList", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Props", () => (
     <Story>

--- a/app/components/blog-link/blog-link.story.tsx
+++ b/app/components/blog-link/blog-link.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { BlogLink } from "./blog-link"
 
-storiesOf("Code of Blog Link")
+storiesOf("Code of Blog Link", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/bullet-item/bullet-item.story.tsx
+++ b/app/components/bullet-item/bullet-item.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { BulletItem } from "./bullet-item"
 
-storiesOf("Code of BulletItem")
+storiesOf("Code of BulletItem", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/button/button.story.tsx
+++ b/app/components/button/button.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Button } from "./"
 
-storiesOf("Button")
+storiesOf("Button", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>

--- a/app/components/checkbox/checkbox.story.tsx
+++ b/app/components/checkbox/checkbox.story.tsx
@@ -5,7 +5,7 @@ import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Checkbox } from "./"
 import { Toggle } from "react-powerplug"
 
-storiesOf("Checkbox")
+storiesOf("Checkbox", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Behaviour", () => (
     <Story>

--- a/app/components/conduct/conduct.story.tsx
+++ b/app/components/conduct/conduct.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Conduct } from "./conduct"
 
-storiesOf("Code of Conduct")
+storiesOf("Code of Conduct", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/contact/contact.story.tsx
+++ b/app/components/contact/contact.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Contact } from "./contact"
 
-storiesOf("Code of Conduct - Contact")
+storiesOf("Code of Conduct - Contact", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/content-link/content-link.story.tsx
+++ b/app/components/content-link/content-link.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { ContentLink } from "./content-link"
 
-storiesOf("Code of ContentLink")
+storiesOf("ContentLink", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/footer/footer.story.tsx
+++ b/app/components/footer/footer.story.tsx
@@ -4,7 +4,7 @@ import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Footer } from "./footer"
 import { Text } from "../text"
 
-storiesOf("Footer")
+storiesOf("Footer", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/form-row/form-row.story.tsx
+++ b/app/components/form-row/form-row.story.tsx
@@ -4,7 +4,7 @@ import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { FormRow } from "./form-row"
 import { Text } from "../text"
 
-storiesOf("FormRow")
+storiesOf("FormRow", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Assembled", () => (
     <Story>

--- a/app/components/gerding-theater/gerding-theater.story.tsx
+++ b/app/components/gerding-theater/gerding-theater.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { GerdingTheater } from "./gerding-theater"
 
-storiesOf("GerdingTheater")
+storiesOf("GerdingTheater", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/getting-to-chain-react/getting-to-chain-react.story.tsx
+++ b/app/components/getting-to-chain-react/getting-to-chain-react.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { GettingToChainReact } from "./getting-to-chain-react"
 
-storiesOf("GettingToChainReact")
+storiesOf("GettingToChainReact", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/photobomb/photobomb.story.tsx
+++ b/app/components/photobomb/photobomb.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Photobomb } from "./photobomb"
 
-storiesOf("Code of Photobomb")
+storiesOf("Code of Photobomb", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/presented-by/presented-by.story.tsx
+++ b/app/components/presented-by/presented-by.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { PresentedBy } from "./presented-by"
 
-storiesOf("PresentedBy")
+storiesOf("PresentedBy", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/rating/rating.story.tsx
+++ b/app/components/rating/rating.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Rating } from "./rating"
 
-storiesOf("Rating")
+storiesOf("Rating", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Props", () => (
     <Story>

--- a/app/components/schedule-cell/schedule-cell.story.tsx
+++ b/app/components/schedule-cell/schedule-cell.story.tsx
@@ -49,7 +49,7 @@ const afterparty: any = {
 }
 
 const noop = () =>
-  void storiesOf("ScheduleCell")
+  void storiesOf("ScheduleCell", module)
     .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
     .add("Presets", () => (
       <Story>

--- a/app/components/schedule-nav/schedule-nav.story.tsx
+++ b/app/components/schedule-nav/schedule-nav.story.tsx
@@ -4,7 +4,7 @@ import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { ScheduleNav } from "./schedule-nav"
 
 const onSelected = (selected: string) =>
-  void storiesOf("ScheduleNav")
+  void storiesOf("ScheduleNav", module)
     .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
     .add("Presets", () => (
       <Story>

--- a/app/components/social-button/social-button.story.tsx
+++ b/app/components/social-button/social-button.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { SocialButton } from "./social-button"
 
-storiesOf("SocialButton")
+storiesOf("SocialButton", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/sponsor-logo/sponsor-logo.story.tsx
+++ b/app/components/sponsor-logo/sponsor-logo.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { SponsorLogo } from "./sponsor-logo"
 
-storiesOf("SponsorLogo")
+storiesOf("SponsorLogo", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/sponsors/sponsors.story.tsx
+++ b/app/components/sponsors/sponsors.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Sponsors } from "./sponsors"
 
-storiesOf("Sponsors")
+storiesOf("Sponsors", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/switch/switch.story.tsx
+++ b/app/components/switch/switch.story.tsx
@@ -5,7 +5,7 @@ import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Toggle } from "react-powerplug"
 import { Switch } from "."
 
-storiesOf("Switch")
+storiesOf("Switch", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Behaviour", () => (
     <Story>

--- a/app/components/text-field/text-field.story.tsx
+++ b/app/components/text-field/text-field.story.tsx
@@ -5,7 +5,7 @@ import { Text } from "../text"
 import { TextField } from "./"
 import { State } from "react-powerplug"
 
-storiesOf("TextField")
+storiesOf("TextField", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Labelling", () => (
     <Story>

--- a/app/components/text/text.story.tsx
+++ b/app/components/text/text.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { Text } from "./text"
 
-storiesOf("Text")
+storiesOf("Text", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Style Presets", () => (
     <Story>

--- a/app/components/travel-option/travel-option.story.tsx
+++ b/app/components/travel-option/travel-option.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { TravelOption } from "./travel-option"
 
-storiesOf("TravelOption")
+storiesOf("TravelOption", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/app/components/wi-fi/wi-fi.story.tsx
+++ b/app/components/wi-fi/wi-fi.story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react-native"
 import { StoryScreen, Story, UseCase } from "../../../storybook/views"
 import { WiFi } from "./wi-fi"
 
-storiesOf("WiFi")
+storiesOf("WiFi", module)
   .addDecorator(fn => <StoryScreen>{fn()}</StoryScreen>)
   .add("Presets", () => (
     <Story>

--- a/test/__snapshots__/storyshots.test.ts.snap
+++ b/test/__snapshots__/storyshots.test.ts.snap
@@ -9728,11 +9728,9 @@ exports[`Storyshots TextField Labelling 1`] = `
                 Name
               </Text>
               <TextInput
-                allowFontScaling={true}
                 onChangeText={[Function]}
                 placeholder="omg your name"
                 placeholderTextColor="#CDD4DA"
-                rejectResponderTermination={true}
                 style={
                   Object {
                     "backgroundColor": "#161637",
@@ -9848,11 +9846,9 @@ exports[`Storyshots TextField Labelling 1`] = `
                 [missing "en-US.storybook.field" translation]
               </Text>
               <TextInput
-                allowFontScaling={true}
                 onChangeText={[Function]}
                 placeholder="[missing \\"en-US.storybook.placeholder\\" translation]"
                 placeholderTextColor="#CDD4DA"
-                rejectResponderTermination={true}
                 style={
                   Object {
                     "backgroundColor": "#161637",
@@ -10000,10 +9996,8 @@ exports[`Storyshots TextField Style Overrides 1`] = `
                 First Name
               </Text>
               <TextInput
-                allowFontScaling={true}
                 onChangeText={[Function]}
                 placeholderTextColor="#CDD4DA"
-                rejectResponderTermination={true}
                 style={
                   Object {
                     "backgroundColor": "#161637",
@@ -10040,10 +10034,8 @@ exports[`Storyshots TextField Style Overrides 1`] = `
                 Last Name
               </Text>
               <TextInput
-                allowFontScaling={true}
                 onChangeText={[Function]}
                 placeholderTextColor="#CDD4DA"
-                rejectResponderTermination={true}
                 style={
                   Object {
                     "backgroundColor": "#161637",
@@ -10159,10 +10151,8 @@ exports[`Storyshots TextField Style Overrides 1`] = `
                 Name
               </Text>
               <TextInput
-                allowFontScaling={true}
                 onChangeText={[Function]}
                 placeholderTextColor="#CDD4DA"
-                rejectResponderTermination={true}
                 style={
                   Object {
                     "backgroundColor": "rebeccapurple",

--- a/test/mock-text-input.ts
+++ b/test/mock-text-input.ts
@@ -1,0 +1,14 @@
+// https://github.com/facebook/jest/issues/3707#issuecomment-311169259
+
+jest.mock("TextInput", () => {
+  const RealComponent = require.requireActual("TextInput")
+  const React = require("React")
+  class TextInput extends React.Component {
+    render() {
+      delete this.props.autoFocus
+      return React.createElement("TextInput", this.props, this.props.children)
+    }
+  }
+  TextInput.propTypes = RealComponent.propTypes
+  return TextInput
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -4,3 +4,4 @@ import "react-native"
 // libraries to mock
 import "./mock-i18n"
 import "./mock-reactotron"
+import "./mock-text-input"


### PR DESCRIPTION
Closes #170 

- Added `module` argument to stories to clean up HMR warnings
- Added a mock for `TextInput` that removes the `autoFocus()` property to make the `Calling .blur() in the test renderer environment is not supported.` go away

<img width="609" alt="Screen Shot 2019-06-26 at 10 15 50 AM" src="https://user-images.githubusercontent.com/6894653/60200657-66df3380-97fb-11e9-93ed-4143998cd593.png">

Note: AsyncStorage warning being handled in #171 
