### PR TITLE
Change graphql fetch policy to network-only

### DIFF
--- a/app/models/environment.ts
+++ b/app/models/environment.ts
@@ -1,5 +1,6 @@
 import { Reactotron } from "../services/reactotron"
 import { Api } from "../services/api"
+import DefaultClient from "apollo-boost"
 
 /**
  * The environment is a place where services and shared dependencies between
@@ -19,5 +20,5 @@ export class Environment {
   /**
    * Our graphql client.
    */
-  graphql: any
+  graphql: DefaultClient<any>
 }

--- a/app/models/talk-store/talk-store.ts
+++ b/app/models/talk-store/talk-store.ts
@@ -2,6 +2,7 @@ import { flow, getEnv, types } from "mobx-state-tree"
 import gql from "graphql-tag"
 import { TalkModel, TalkSnapshot } from "../talk"
 import { SettingModel, SettingSnapshot } from "../setting"
+import { Environment } from "../environment"
 
 export const TalkStoreModel = types
   .model()
@@ -21,7 +22,9 @@ export const TalkStoreModel = types
   .actions(self => ({
     getAll: flow(function*() {
       self.status = "pending"
-      const result = yield getEnv(self).graphql.query({
+      const env: Environment = getEnv(self)
+      const result = yield env.graphql.query({
+        fetchPolicy: "network-only",
         query: gql`
           query Talks {
             settings {


### PR DESCRIPTION
The default `cache-first` policy meant that any subsequent requests to re-fetch the schedule weren't actually getting any new data. 

I tried to use `cache-and-network`, but it doesn't work with the `.query` function, according to ﻿https://github.com/apollographql/apollo-client/issues/3130